### PR TITLE
Disable failing checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,8 +4,8 @@ on:
   push:
 
 jobs:
-  security:
-    uses: lidofinance/linters/.github/workflows/security.yml@master
+  # security:
+  #   uses: lidofinance/linters/.github/workflows/security.yml@master
 
   docker:
     uses: lidofinance/linters/.github/workflows/docker.yml@master

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,8 +4,10 @@ on:
   push:
 
 jobs:
-  # security:
-  #   uses: lidofinance/linters/.github/workflows/security.yml@master
+  security:
+    uses: lidofinance/linters/.github/workflows/security.yml@master
+    with:
+      skip-codeql: true
 
   docker:
     uses: lidofinance/linters/.github/workflows/docker.yml@master


### PR DESCRIPTION
### Description

Security checks were failing, because codeql wasn't initialized, but we probably don't codeql checks in this repo with mostly static content.