### PR TITLE
Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Before setting up the project, ensure you have the following installed:
 
 - **Homebrew** (Mac/Linux): Used to install other necessary tools. [Installation instructions](https://brew.sh/).
-- **Node.js**: The required Node.js version is specified in the `.nvmrc` file for `nvm` users (`nvm use` to install and choose Node version frome .nvmrc) and `package.json`.
+- **Node.js**: The required Node.js version is specified in the `.nvmrc` file for `nvm` users (`nvm use` to install and choose Node version from .nvmrc) and `package.json`.
 - **Yarn**: Required for handling project dependencies.
 - **Colima** or **Docker Desktop**:
   - **Colima** (Mac/Linux): A tool to run Docker containers on macOS with minimal resource overhead. It is an alternative to Docker Desktop designed to be simple and fast. [Colima's GitHub](https://github.com/abiosoft/colima):

--- a/ethereum-staking-widget/faq-withdrawals-page-request-tab.md
+++ b/ethereum-staking-widget/faq-withdrawals-page-request-tab.md
@@ -45,7 +45,7 @@ faq:
     question: How long does it take to withdraw?
   - answer: |-
       * The amount of stETH in the queue.
-      * Perfomance of the validator poolside.
+      * Performance of the validator poolside.
       * Exit queue on the Beacon chain.
       * Demand for staking and unstaking.
     question: What are the factors affecting the withdrawal time?


### PR DESCRIPTION
# Fix: Corrected typos in documentation

## What was changed
1. **Corrected typo** `frome` to `from` in `README.md` (line 10).
2. **Corrected typo** `Perfomance` to `Performance` in `faq-withdrawals-page-request-tab.md` (line 48).

## Why these changes were made
- **Fixing typos** improves the clarity, readability, and professionalism of the documentation.
- Correct and clear documentation ensures better understanding for contributors and users.

## Additional Notes
- These changes focus solely on correcting typographical errors in documentation and do not affect any code functionality.
