### PR TITLE
ci: update actions/upload-pages-artifact version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,10 +49,10 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updated to v3
Changes in the action require update of the `actions/deploy-pages` version
https://github.com/actions/upload-pages-artifact/releases/tag/v2.0.0
https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0