### PR TITLE
feat: changed a name of vault in steth-in-defi

### DIFF
--- a/lido-landing/steth-in-defi/projects/0da2bbf2-61e7-4703-8a5c-8386beb92a83.md
+++ b/lido-landing/steth-in-defi/projects/0da2bbf2-61e7-4703-8a5c-8386beb92a83.md
@@ -1,6 +1,6 @@
 ---
 id: 0da2bbf2-61e7-4703-8a5c-8386beb92a83
-name: Amphor Restaked ETH
+name: MEV Capital restaked ETH
 categoryId: "4"
 curatorId: 9ef88be9-d6ea-4487-bc0c-eec28580f324
 protocol: on Mellow


### PR DESCRIPTION
Initially the name of this vault was changed on the Mellow web site - https://app.mellow.finance/vaults/ethereum-amphreth