### PR TITLE
fix: file handling errors and ensure consistent logging order

### DIFF
--- a/scripts/check-domain-agnostic.mjs
+++ b/scripts/check-domain-agnostic.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env -S yarn zx
 
+import { glob } from 'glob';
+import fs from 'fs/promises';
+
 class CheckError {
   constructor(message, line) {
     this.message = message;
@@ -88,28 +91,28 @@ const main = async () => {
     "lido-landing/l2-audits.md",
     "lido-landing/ecosystem/**/*",
     "lido-landing/validators/**/*",
-  ]);
+  ], { nodir: true });
 
   let errors = false;
-  await Promise.all(
-    pages.map(async (page) => {
-      const content = await fs.readFile(page, "utf-8");
 
-      const results = [
-        ...checkDomainMention(content),
-        ...checkVariablesUsage(content),
-      ];
+  for (const page of pages) {
+    const content = await fs.readFile(page, "utf-8");
 
-      if (results.length != 0) {
-        for (let result of results) {
-          console.error(`${page}:${result.line}: 🚨 ${result.message}`);
-        }
-        errors = true;
-      } else {
-        console.log(`${page}: ✅ Ok`);
+    const results = [
+      ...checkDomainMention(content),
+      ...checkVariablesUsage(content),
+    ];
+
+    if (results.length != 0) {
+      for (let result of results) {
+        console.error(`${page}:${result.line}: 🚨 ${result.message}`);
       }
-    }),
-  );
+      errors = true;
+    } else {
+      console.log(`${page}: ✅ Ok`);
+    }
+  }
+
   if (errors) {
     process.exit(1);
   }


### PR DESCRIPTION
fixed a couple of issues in the file processing script:

* imported `glob` and `fs/promises` to prevent `ReferenceError`.
* added `{ nodir: true }` to `glob` calls to exclude directories and keep file handling consistent.
* replaced `Promise.all` with `for...of` to ensure errors are logged in a predictable order.
