### PR TITLE
fix: remove redundant comma in EarnETH description

### DIFF
--- a/lido-landing/stake-and-earn.md
+++ b/lido-landing/stake-and-earn.md
@@ -10,7 +10,7 @@ products:
     isNew: false
     isButtonDisabled: false
     depositLink: "{{ethereum_stake_url}}/earn/eth"
-    description: EarnETH is an ETH growth vault allocating ETH and stETH across leading, blue-chip DeFi protocols meant to optimize for capital efficiency
+    description: EarnETH is an ETH growth vault allocating ETH and stETH across leading blue-chip DeFi protocols meant to optimize for capital efficiency
     buttonLabel: Deposit
   - urgentMode:
       isActive: false


### PR DESCRIPTION
Delete the unnecessary comma from EarnETH card